### PR TITLE
Updated spark-mongodb connector source

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ A curated list of awesome [Apache Spark](https://spark.apache.org/) packages and
 * [Spark CSV](https://github.com/databricks/spark-csv) - CSV reader and writer.
 * [Spark Avro](https://github.com/databricks/spark-avro) - [Apache Avro](https://avro.apache.org/) reader and writer.
 * [Spark XML](https://github.com/databricks/spark-xml) - XML parser and writer.
-* [Spark-Mongodb](https://github.com/Stratio/Spark-MongoDB) - MongoDB reader and writer.
+* [Spark-Mongodb](https://github.com/mongodb/mongo-spark) - MongoDB reader and writer.
 * [Spark Cassandra Connector](https://github.com/datastax/spark-cassandra-connector) - Cassandra support including data source and API and support for arbitrary queries.
 * [Spark Riak Connector](https://github.com/basho/spark-riak-connector) - Riak TS & Riak KV connector.
 * [Mongo-Spark](https://github.com/mongodb/mongo-spark) - Official MongoDB connector.


### PR DESCRIPTION
Source has been changed to URL to official repository as it's in continuous development.