### PR TITLE
Add list of deprecated resources

### DIFF
--- a/deprecated.md
+++ b/deprecated.md
@@ -1,0 +1,19 @@
+# Deprecated Resources
+
+This page lists resources, which used to be included in the Awesome Spark, but __are no longer__ recommended. This usually happens if the resource is no longer maintained or relevant.
+
+## Table of Contents
+
+## License
+
+<p xmlns:dct="http://purl.org/dc/terms/">
+<a rel="license" href="http://creativecommons.org/publicdomain/mark/1.0/">
+<img src="http://i.creativecommons.org/p/mark/1.0/88x31.png"
+     style="border-style: none;" alt="Public Domain Mark" />
+</a>
+<br />
+This work (<span property="dct:title">Awesome Spark</span>, by <a href="https://github.com/awesome-spark/awesome-spark" rel="dct:creator">https://github.com/awesome-spark/awesome-spark</a>), identified by <a href="https://github.com/zero323" rel="dct:publisher"><span property="dct:title">Maciej Szymkiewicz</span></a>, is free of known copyright restrictions.
+</p>
+
+Apache Spark, Spark, Apache, and the Spark logo are <a href="https://www.apache.org/foundation/marks/">trademarks</a> of
+  <a href="http://www.apache.org">The Apache Software Foundation</a>. This compilation is not endorsed by The Apache Software Foundation.


### PR DESCRIPTION
Rationale:

- It can be interesting for historical reasons and easier than browsing git history.
- Can be relevant for users stuck with legacy versions.
- Can serve as a resource for people looking for an abandoned projects to adopt.

I am not sure if it is really necessary or desired so let's discuss this first.