### PR TITLE
Add Flintrock

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,7 @@ Users of Apache Spark may choose between different the Python, R, Scala and Java
 * [silex](https://github.com/willb/silex) - Collection of tools varying from ML extensions to additional RDD methods.
 * [sparkly](https://github.com/Tubular/sparkly) - Helpers & syntactic sugar for PySpark.
 * [pyspark-stubs](https://github.com/zero323/pyspark-stubs) - Static type annotations for PySpark.
+* [Flintrock](https://github.com/nchammas/flintrock) - A command-line tool for launching Spark clusters on EC2.
 
 ### Natural Language Processing
 


### PR DESCRIPTION
I used the word "Spark" in the description despite the [Contributing guidelines](https://github.com/awesome-spark/awesome-spark/blob/master/contributing.md) because it may not be clear to some what kind of clusters we are talking about, since clustering is also a topic in machine learning. If you think the context is clear, I'm happy to remove the "Spark".

Closes #100.
