### PR TITLE
add spark-nlp to Natural Language Processing

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ Users of Apache Spark may choose between different the Python, R, Scala and Java
 * [pyspark-stubs](https://github.com/zero323/pyspark-stubs) - Static type annotations for PySpark.
 
 ### Natural Language Processing
-
+* [spark-nlp](https://github.com/JohnSnowLabs/spark-nlp) - High Performance NLP for Apache Spark.
 * [spark-corenlp](https://github.com/databricks/spark-corenlp) - DataFrame wrapper for [Stanford CoreNLP](https://stanfordnlp.github.io/CoreNLP/).
 
 ### Streaming

--- a/README.md
+++ b/README.md
@@ -119,8 +119,8 @@ Users of Apache Spark may choose between different the Python, R, Scala and Java
 * [pyspark-stubs](https://github.com/zero323/pyspark-stubs) - Static type annotations for PySpark.
 
 ### Natural Language Processing
-* [spark-nlp](https://github.com/JohnSnowLabs/spark-nlp) - High Performance NLP for Apache Spark.
 * [spark-corenlp](https://github.com/databricks/spark-corenlp) - DataFrame wrapper for [Stanford CoreNLP](https://stanfordnlp.github.io/CoreNLP/).
+* [spark-nlp](https://github.com/JohnSnowLabs/spark-nlp) - High Performance NLP for Apache Spark.
 
 ### Streaming
 

--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ Users of Apache Spark may choose between different the Python, R, Scala and Java
 
 ### Natural Language Processing
 * [spark-corenlp](https://github.com/databricks/spark-corenlp) - DataFrame wrapper for [Stanford CoreNLP](https://stanfordnlp.github.io/CoreNLP/).
-* [spark-nlp](https://github.com/JohnSnowLabs/spark-nlp) - High Performance NLP for Apache Spark.
+* [spark-nlp](https://github.com/JohnSnowLabs/spark-nlp) - Natural language understanding library. 
 
 ### Streaming
 

--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ Users of Apache Spark may choose between different the Python, R, Scala and Java
 
 ### Natural Language Processing
 * [spark-corenlp](https://github.com/databricks/spark-corenlp) - DataFrame wrapper for [Stanford CoreNLP](https://stanfordnlp.github.io/CoreNLP/).
-* [spark-nlp](https://github.com/JohnSnowLabs/spark-nlp) - Natural language understanding library. 
+* [spark-nlp](https://github.com/JohnSnowLabs/spark-nlp) - Natural language processing library built on top of Apache Spark ML. 
 
 ### Streaming
 


### PR DESCRIPTION
Adding [spark-nlp](https://github.com/JohnSnowLabs/spark-nlp) to Natural Language Processing (at the end).