### PR TITLE
[WIP] Add DEPRECATED.md and move Spark-Mongodb

### DIFF
--- a/DEPRECATED.md
+++ b/DEPRECATED.md
@@ -1,0 +1,11 @@
+# Awesome Spark ‒ Deprecated Items  
+
+This page contains items once included in Awesome Spark, but removed from the list for various reasons. While no longer recommended, these might be interesting for various of reasons.
+
+- [Packages](#packages)
+  - [SQL Data Sources](#sql-data-sources)
+
+
+### SQL Data Sources
+
+* [Spark-Mongodb](https://github.com/Stratio/Spark-MongoDB) (archived by the owner) - MongoDB reader and writer.

--- a/README.md
+++ b/README.md
@@ -72,7 +72,6 @@ SparkSQL has [serveral built-in Data Sources](https://spark.apache.org/docs/late
 * [Spark CSV](https://github.com/databricks/spark-csv) <img src="https://img.shields.io/github/last-commit/databricks/spark-csv.svg"> - CSV reader and writer (obsolete since Spark 2.0 [[SPARK-12833]](https://issues.apache.org/jira/browse/SPARK-12833)).
 * [Spark Avro](https://github.com/databricks/spark-avro) <img src="https://img.shields.io/github/last-commit/databricks/spark-avro.svg"> - [Apache Avro](https://avro.apache.org/) reader and writer (obselete since Spark 2.4 [[SPARK-24768]](https://issues.apache.org/jira/browse/SPARK-24768)).
 * [Spark XML](https://github.com/databricks/spark-xml) <img src="https://img.shields.io/github/last-commit/databricks/spark-xml.svg"> - XML parser and writer.
-* [Spark-Mongodb](https://github.com/Stratio/Spark-MongoDB) <img src="https://img.shields.io/github/last-commit/Stratio/Spark-MongoDB.svg"> - MongoDB reader and writer.
 * [Spark Cassandra Connector](https://github.com/datastax/spark-cassandra-connector) <img src="https://img.shields.io/github/last-commit/datastax/spark-cassandra-connector.svg"> - Cassandra support including data source and API and support for arbitrary queries.
 * [Spark Riak Connector](https://github.com/basho/spark-riak-connector) <img src="https://img.shields.io/github/last-commit/basho/spark-riak-connector.svg"> - Riak TS & Riak KV connector.
 * [Mongo-Spark](https://github.com/mongodb/mongo-spark) <img src="https://img.shields.io/github/last-commit/mongodb/mongo-spark.svg"> - Official MongoDB connector.


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Please make sure that you've read our contributing guide:
https://github.com/awesome-spark/awesome-spark/blob/main/contributing.md

Please make sure that the title of your PR reflects starts with one of the following:

- `[ADD]` - for additions to Awesome Spark.
- `[REMOVE]` - for deletions from Awesome Spark.
- `[DEPRECATE]` - for deprecations.
- `[MISC]` - for maintenance and fixes (typos, grammar).
-->

<!--
Please provide general description of the project
For License, if applicable, you can use trove classifiers https://pypi.org/classifiers/
-->

## Description

This PR adds a new `DEPRECATED.md` file and moves the following

- Name: Spark-MongoDB
- URL:  https://github.com/Stratio/Spark-MongoDB

from the main list.

## Why

<!--
Please describe why this resource should be added to or removed from Awesome Spark

Valid reasons for removal include, but are not limited to:

- Resource is no longer available.
- Resource is no longer maintained.
-->

Spark-related projects are often short lived, even if developed by major players. At the moment, we have a bunch of items on the list, that haven't been updated in a long time or are simply archived by the owners (that's the case for Spark-MongoDB).

We could simply drop these, but they might be of some interest for folks:

- Using legacy Spark versions (from my experience this happens quite a lot in large companies with in-house deployments).
- Interested in different patterns, including failed ones.
- Llooking for projects to adopt.

Related to #199 