### PR TITLE
[ADD] Ready-to-use Docker image from Data Mechanics

### DIFF
--- a/README.md
+++ b/README.md
@@ -205,6 +205,7 @@ SparkSQL has [serveral built-in Data Sources](https://spark.apache.org/docs/late
 
 - [jupyter/docker-stacks/pyspark-notebook](https://github.com/jupyter/docker-stacks/tree/master/pyspark-notebook) - PySpark with Jupyter Notebook and Mesos client.
 - [sequenceiq/docker-spark](https://github.com/sequenceiq/docker-spark) - Yarn images from [SequenceIQ](http://www.sequenceiq.com/).
+- [datamechanics/spark](https://hub.docker.com/r/datamechanics/spark) - an easy to setup Docker image for Apache Spark from [Data Mechanics](https://www.datamechanics.co/)
 
 ### Miscellaneous
 

--- a/README.md
+++ b/README.md
@@ -205,7 +205,7 @@ SparkSQL has [serveral built-in Data Sources](https://spark.apache.org/docs/late
 
 - [jupyter/docker-stacks/pyspark-notebook](https://github.com/jupyter/docker-stacks/tree/master/pyspark-notebook) - PySpark with Jupyter Notebook and Mesos client.
 - [sequenceiq/docker-spark](https://github.com/sequenceiq/docker-spark) - Yarn images from [SequenceIQ](http://www.sequenceiq.com/).
-- [datamechanics/spark](https://hub.docker.com/r/datamechanics/spark) - an easy to setup Docker image for Apache Spark from [Data Mechanics](https://www.datamechanics.co/)
+- [datamechanics/spark](https://hub.docker.com/r/datamechanics/spark) - an easy to setup Docker image for Apache Spark from [Data Mechanics](https://www.datamechanics.co/).
 
 ### Miscellaneous
 

--- a/README.md
+++ b/README.md
@@ -205,7 +205,7 @@ SparkSQL has [serveral built-in Data Sources](https://spark.apache.org/docs/late
 
 - [jupyter/docker-stacks/pyspark-notebook](https://github.com/jupyter/docker-stacks/tree/master/pyspark-notebook) - PySpark with Jupyter Notebook and Mesos client.
 - [sequenceiq/docker-spark](https://github.com/sequenceiq/docker-spark) - Yarn images from [SequenceIQ](http://www.sequenceiq.com/).
-- [datamechanics/spark](https://hub.docker.com/r/datamechanics/spark) - an easy to setup Docker image for Apache Spark from [Data Mechanics](https://www.datamechanics.co/).
+- [datamechanics/spark](https://hub.docker.com/r/datamechanics/spark) - An easy to setup Docker image for Apache Spark from [Data Mechanics](https://www.datamechanics.co/).
 
 ### Miscellaneous
 


### PR DESCRIPTION
## Description

- Name: Data Mechanics Docker image
- URL:  https://hub.docker.com/r/datamechanics/spark
- License: ? (I didn't find the license information, used the project for personal use)

## Why
The project should be added to the list because it gives a very easy way to quickly test Apache Spark applications on Kubernetes. An example here: https://github.com/bartosz25/spark-playground/blob/d53289b125242773e0e4d5d269bf6f303940076b/spark-stage-scheduling/Dockerfile There is no need to build Apache Spark Docker images from the sources. Simply create the package with your code and copy it to the `Dockerfile` extending Data Mechanics' Spark image.

## Checklist

<!--
Please use this checklist for additions to Awesome Spark
-->

- [x] Item hasn't been proposed yet (there is no open PR, it hasn't been rejected or removed).
- [x] Item is added at the on of the relevant section.
- [x] Description ends with period and doesn't contain trailing whitespace.
