### PR TITLE
[MISC] Add CoC checkbox to PR template.

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE
+++ b/.github/PULL_REQUEST_TEMPLATE
@@ -43,3 +43,7 @@ Please use this checklist for additions to Awesome Spark
 - [ ] Item hasn't been proposed yet (there is no open PR, it hasn't been rejected or removed).
 - [ ] Item is added at the on of the relevant section.
 - [ ] Description ends with period and doesn't contain trailing whitespace.
+
+## Code of Conduct
+
+- [ ] I agree to follow Awesome Spark's [Code of Conduct](https://github.com/awesome-spark/awesome-spark/blob/main/CODE_OF_CONDUCT.md).


### PR DESCRIPTION
## Description

This PR adds Code of Conduct section to the PR template with result looking like this:

![rendered pr template image](https://user-images.githubusercontent.com/1554276/145719093-d8c30fb3-dd42-4b61-8ece-51ef9a012db6.png)


## Why

Now, when we have CoC it is a good idea to educate contributors about its existence.

## Code of Conduct

- [x] I agree to follow Awesome Spark's [Code of Conduct](https://github.com/awesome-spark/awesome-spark/blob/main/CODE_OF_CONDUCT.md).