### PR TITLE
[ADD] DataComPy

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,6 +140,7 @@ SparkSQL has [serveral built-in Data Sources](https://spark.apache.org/docs/late
 * [pyspark-stubs](https://github.com/zero323/pyspark-stubs) <img src="https://img.shields.io/github/last-commit/zero323/pyspark-stubs.svg"> - Static type annotations for PySpark (obsolete since Spark 3.1. See [SPARK-32681](https://issues.apache.org/jira/browse/SPARK-32681)).
 * [Flintrock](https://github.com/nchammas/flintrock) <img src="https://img.shields.io/github/last-commit/nchammas/flintrock.svg"> - A command-line tool for launching Spark clusters on EC2.
 * [Optimus](https://github.com/ironmussa/Optimus/) <img src="https://img.shields.io/github/last-commit/ironmussa/Optimus.svg"> - Data Cleansing and Exploration utilities with the goal of simplifying data cleaning.
+* [DataComPy](https://github.com/capitalone/datacompy) <img src="https://img.shields.io/github/last-commit/capitalone/datacompy.svg"> - A Python library that facilitates the comparison of two DataFrames. The library goes beyond basic equality checks by providing detailed insights into discrepancies at both row and column levels.
 
 ### Natural Language Processing
 * [spark-corenlp](https://github.com/databricks/spark-corenlp) <img src="https://img.shields.io/github/last-commit/databricks/spark-corenlp.svg"> - DataFrame wrapper for [Stanford CoreNLP](https://stanfordnlp.github.io/CoreNLP/).


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Please make sure that you've read our contributing guide:
https://github.com/awesome-spark/awesome-spark/blob/main/contributing.md

Please make sure that the title of your PR reflects starts with one of the following:

- `[ADD]` - for additions to Awesome Spark.
- `[REMOVE]` - for deletions from Awesome Spark.
- `[DEPRECATE]` - for deprecations.
- `[MISC]` - for maintenance and fixes (typos, grammar).
-->

<!--
Please provide general description of the project
For License, if applicable, you can use trove classifiers https://pypi.org/classifiers/
-->

## Description

- Name: DataComPy
- URL:  https://github.com/capitalone/datacompy
- License: Apache 2.0

## Why

DataComPy is a package to compare two Spark Data Frames. Originally started to be something of a replacement for SAS's PROC COMPARE for Pandas DataFrames with some more functionality than just Pandas.DataFrame.equals(Pandas.DataFrame). 

It provides stats and lets users adjust for match accuracy, and specify absolute or relative tolerance for comparison of numeric columns. The package also allows via Fugue to compare Spark DataFrames against other types so: Spark vs Pandas, Spark vs Polars, Spark vs DuckDB etc.

## Checklist

<!--
Please use this checklist for additions to Awesome Spark
-->

- [x] Item hasn't been proposed yet (there is no open PR, it hasn't been rejected or removed).
- [x] Item is added at the on of the relevant section.
- [x] Description ends with period and doesn't contain trailing whitespace.

## Code of Conduct

- [x] I agree to follow Awesome Spark's [Code of Conduct](https://github.com/awesome-spark/awesome-spark/blob/main/CODE_OF_CONDUCT.md).
