### PR TITLE
[REMOVE] table of contents

### DIFF
--- a/DEPRECATED.md
+++ b/DEPRECATED.md
@@ -2,9 +2,6 @@
 
 This page contains items once included in Awesome Spark, but removed from the list for various reasons. While no longer recommended, these might be interesting for various of reasons.
 
-- [Packages](#packages)
-  - [SQL Data Sources](#sql-data-sources)
-
 ### Language Bindings
 
 * [Flambo](https://github.com/yieldbot/flambo) <img src="https://img.shields.io/github/last-commit/yieldbot/flambo.svg"> - Clojure DSL.

--- a/README.md
+++ b/README.md
@@ -8,44 +8,11 @@ _Apache Spark is an open-source cluster-computing framework. Originally develope
 
 Users of Apache Spark may choose between different the Python, R, Scala and Java programming languages to interface with the Apache Spark APIs.
 
-## Contents
-
-- [Packages](#packages)
-  - [Language Bindings](#language-bindings)
-  - [Notebooks and IDEs](#notebooks-and-ides)
-  - [General Purpose Libraries](#general-purpose-libraries)
-  - [SQL Data Sources](#sql-data-sources)
-  - [Storage](#storage)
-  - [Bioinformatics](#bioinformatics)
-  - [GIS](#gis)
-  - [Time Series Analytics](#time-series-analytics)
-  - [Graph Processing](#graph-processing)
-  - [Machine Learning Extension](#machine-learning-extension)
-  - [Middleware](#middleware)
-  - [Utilities](#utilities)
-  - [Natural Language Processing](#natural-language-processing)
-  - [Streaming](#streaming)
-  - [Interfaces](#interfaces)
-  - [Testing](#testing)
-  - [Web Archives](#web-archives)
-  - [Workflow Management](#workflow-management)
-
-- [Resources](#resources)
-  - [Books](#books)
-  - [Papers](#papers)
-  - [MOOCS](#moocs)
-  - [Workshops](#workshops)
-  - [Projects Using Spark](#projects-using-spark)
-  - [Docker Images](#docker-images)
-  - [Miscellaneous](#miscellaneous)
-
-
 ## Packages
 
 ### Language Bindings
 
 * [Kotlin for Apache Spark](https://github.com/Kotlin/kotlin-spark-api) <img src="https://img.shields.io/github/last-commit/Kotlin/kotlin-spark-api.svg"> - Kotlin API bindings and extensions.
-* [Flambo](https://github.com/yieldbot/flambo) <img src="https://img.shields.io/github/last-commit/yieldbot/flambo.svg"> - Clojure DSL.
 * [Mobius](https://github.com/Microsoft/Mobius) <img src="https://img.shields.io/github/last-commit/Microsoft/Mobius.svg"> - C# bindings (Deprecated in favor of .NET for Apache Spark).
 * [.NET for Apache Spark](https://github.com/dotnet/spark) <img src="https://img.shields.io/github/last-commit/dotnet/spark.svg"> - .NET bindings.
 * [sparklyr](https://github.com/rstudio/sparklyr) <img src="https://img.shields.io/github/last-commit/rstudio/sparklyr.svg"> - An alternative R backend, using [`dplyr`](https://github.com/hadley/dplyr).


### PR DESCRIPTION
## Description

Remove the table of contents.

## Why

GitHub has a built-in table of contents now:

<img width="817" alt="Screenshot 2024-09-17 at 4 05 45 PM" src="https://github.com/user-attachments/assets/ab3a3748-0c66-4080-ad75-dd12da56aa20">

## Checklist

<!--
Please use this checklist for additions to Awesome Spark
-->

- [X] Item hasn't been proposed yet (there is no open PR, it hasn't been rejected or removed).
- [ ] Item is added at the on of the relevant section.
- [ ] Description ends with period and doesn't contain trailing whitespace.

## Code of Conduct

- [X] I agree to follow Awesome Spark's [Code of Conduct](https://github.com/awesome-spark/awesome-spark/blob/main/CODE_OF_CONDUCT.md).
