### PR TITLE
[ADD] sparkMeasure & CERN SparkPlugins

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,8 @@ SparkSQL has [serveral built-in Data Sources](https://spark.apache.org/docs/late
 ### Monitoring
 
 * [Data Mechanics Delight](https://github.com/datamechanics/delight) <img src="https://img.shields.io/github/last-commit/datamechanics/delight.svg"> - Cross-platform monitoring tool (Spark UI / Spark History Server replacement).
+* [Spark Measure](https://github.com/LucaCanali/sparkMeasure) <img src="https://img.shields.io/github/last-commit/LucaCanali/sparkMeasure.svg"> - A tool and library designed for efficient analysis and troubleshooting of Apache Spark jobs.
+* [CERN Spark Plugins](https://github.com/cerndb/SparkPlugins) <img src="https://img.shields.io/github/last-commit/cerndb/SparkPlugins.svg"> - extend Apache Spark with custom metrics and executors' startup actions.
 
 ### Utilities
 


### PR DESCRIPTION
<!--
Thanks for sending a pull request!

Please make sure that you've read our contributing guide:
https://github.com/awesome-spark/awesome-spark/blob/main/contributing.md

Please make sure that the title of your PR reflects starts with one of the following:

- `[ADD]` - for additions to Awesome Spark.
- `[REMOVE]` - for deletions from Awesome Spark.
- `[DEPRECATE]` - for deprecations.
- `[MISC]` - for maintenance and fixes (typos, grammar).
-->

<!--
Please provide general description of the project
For License, if applicable, you can use trove classifiers https://pypi.org/classifiers/
-->

## Description

### Spark Measure

- Name: Spark Measure
- URL: https://github.com/LucaCanali/sparkMeasure
- License: Apache-2.0

### CERN Spark Plugins

- Name: CERN Spark Plugins
- URL: https://github.com/cerndb/SparkPlugins
- License: Apache-2.0

## Why

<!--
Please describe why this resource should be added to or removed from Awesome Spark

Valid reasons for removal include, but are not limited to:

- Resource is no longer available.
- Resource is no longer maintained.
-->

These tools provides the way to measure Spark resources usage (CPU time, peak memory, IO and so on), as well as record the amount of read/written data (bytes, rows, etc). Both implemented as SparkListeners.

CERN Spark Plugins also provides custom listeners for collecting storage response times (S3, HDFS, Oracle OCI).

## Checklist

<!--
Please use this checklist for additions to Awesome Spark
-->

- [X] Item hasn't been proposed yet (there is no open PR, it hasn't been rejected or removed).
- [X] Item is added at the on of the relevant section.
- [X] Description ends with period and doesn't contain trailing whitespace.

## Code of Conduct

- [X] I agree to follow Awesome Spark's [Code of Conduct](https://github.com/awesome-spark/awesome-spark/blob/main/CODE_OF_CONDUCT.md).
